### PR TITLE
feat: support custom celEnvs when running expressions

### DIFF
--- a/structtemplater.go
+++ b/structtemplater.go
@@ -11,7 +11,7 @@ type StructTemplater struct {
 	Values map[string]interface{}
 	// IgnoreFields from walking where key is field name and value is field type
 	IgnoreFields map[string]string
-	Funcs        map[string]func() any
+	Funcs        map[string]any
 	DelimSets    []Delims
 	// If specified create a function for each value so that is can be accessed via {{ value }} in addition to {{ .value }}
 	ValueFunctions bool
@@ -97,7 +97,7 @@ func (w StructTemplater) Template(val string) (string, error) {
 		return val, nil
 	}
 	if w.Funcs == nil {
-		w.Funcs = make(map[string]func() any)
+		w.Funcs = make(map[string]any)
 	}
 	if w.ValueFunctions {
 		for k, v := range w.Values {

--- a/template_test.go
+++ b/template_test.go
@@ -19,7 +19,7 @@ func TestCacheKeyConsistency(t *testing.T) {
 	{
 		tt := Template{
 			Expression: "{{.name}}{{.age}}",
-			Functions: map[string]func() any{
+			Functions: map[string]any{
 				"hello": hello,
 				"Hello": foo,
 				"foo":   foo,
@@ -41,7 +41,7 @@ func TestCacheKeyConsistency(t *testing.T) {
 			Template:   "{{.name}}{{.age}}",
 			LeftDelim:  "{{",
 			RightDelim: "}}",
-			Functions: map[string]func() any{
+			Functions: map[string]any{
 				"hello": hello,
 				"Hello": foo,
 				"foo":   foo,

--- a/tests/cel_test.go
+++ b/tests/cel_test.go
@@ -49,7 +49,7 @@ func runTests(t *testing.T, tests []Test) {
 }
 
 func TestFunctions(t *testing.T) {
-	funcs := map[string]func() any{
+	funcs := map[string]any{
 		"fn": func() any {
 			return map[string]any{
 				"a": "b",

--- a/tests/gomplate_test.go
+++ b/tests/gomplate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGomplateFunctions(t *testing.T) {
-	funcs := map[string]func() any{
+	funcs := map[string]any{
 		"fn": func() any {
 			return map[string]any{
 				"a": "b",


### PR DESCRIPTION
Adds support for 
- passing in template function of arbitrary signature instead of just `func() any`. Required in playbook actions, where getAction() needs to take in an argument
- For cel expressions, complex functions can be supplied using the newly added `gomplate.CelEnvs` field

Disable template caching if custom functions are provided