### PR TITLE
fix: map templating with yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/text v0.14.0
 	golang.org/x/tools v0.16.1
 	google.golang.org/protobuf v1.32.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
@@ -69,7 +69,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/client-go v0.28.2 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect

--- a/structtemplater.go
+++ b/structtemplater.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/mitchellh/reflectwalk"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type StructTemplater struct {

--- a/structtemplater_test.go
+++ b/structtemplater_test.go
@@ -138,11 +138,11 @@ var tests = []test{
 			Template: "world",
 			JSONMap: map[string]any{
 				"a": map[string]any{
-					"b": map[any]any{
+					"b": map[string]any{
 						"c": "world",
 					},
 					"j": []any{
-						map[any]any{
+						map[string]any{
 							"l": "world",
 						},
 					},
@@ -178,7 +178,7 @@ var tests = []test{
 							"image": "kennethreitz/httpbin:latest",
 							"ports": []any{
 								map[string]any{
-									"containerPort": 4,
+									"containerPort": 80,
 								},
 							},
 						},
@@ -193,18 +193,18 @@ var tests = []test{
 				"metadata": map[string]any{
 					"name":      "httpbin-world",
 					"namespace": "development",
-					"labels": map[any]any{
+					"labels": map[string]any{
 						"app": "httpbin",
 					},
 				},
 				"spec": map[string]any{
 					"containers": []any{
-						map[any]any{
+						map[string]any{
 							"name":  "httpbin",
 							"image": "kennethreitz/httpbin:latest",
 							"ports": []any{
-								map[any]any{
-									"containerPort": 4,
+								map[string]any{
+									"containerPort": 80,
 								},
 							},
 						},


### PR DESCRIPTION
`gopkg.in/yaml.v2` would unmarshall back to map with keys as `any`.

That caused an issue when applying a kubernetes manifest `cannot copy map with non-assignable keys: interface {} string`.

`yaml.v3` seems to use string as the default map key type.