### PR TITLE
feat: support templating struct fields of type []byte

### DIFF
--- a/structtemplater.go
+++ b/structtemplater.go
@@ -54,6 +54,16 @@ func (w StructTemplater) StructField(f reflect.StructField, v reflect.Value) err
 		}
 		v.SetString(val)
 
+	case reflect.Slice:
+		switch v.Type().Elem().Kind() {
+		case reflect.Uint8:
+			val, err := w.Template(string(v.Bytes()))
+			if err != nil {
+				return err
+			}
+			v.SetBytes([]byte(val))
+		}
+
 	case reflect.Map:
 		if len(v.MapKeys()) != 0 {
 			newMap := reflect.MakeMap(v.Type())

--- a/structtemplater_test.go
+++ b/structtemplater_test.go
@@ -1,6 +1,7 @@
 package gomplate
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +11,7 @@ type Test struct {
 	Template   string `template:"true"`
 	NoTemplate string
 	Inner      Inner
+	Properties json.RawMessage   `template:"true"`
 	JSONMap    map[string]any    `template:"true"`
 	Labels     map[string]string `template:"true"`
 	LabelsRaw  map[string]string
@@ -29,6 +31,21 @@ type test struct {
 
 var tests = []test{
 	{
+		name: "template byte slice",
+		StructTemplater: StructTemplater{
+			RequiredTag: "template",
+			Values: map[string]any{
+				"msg": "world",
+			},
+		},
+		Input: &Test{
+			Properties: json.RawMessage(`{"name": "{{.msg}}"}`),
+		},
+		Output: &Test{
+			Properties: json.RawMessage(`{"name": "world"}`),
+		},
+	},
+	{
 		name: "template and no template",
 		StructTemplater: StructTemplater{
 			RequiredTag: "template",
@@ -43,6 +60,7 @@ var tests = []test{
 		Output: &Test{
 			Template:   "hello world",
 			NoTemplate: "hello {{.msg}}",
+			Properties: json.RawMessage{},
 		},
 	},
 	{
@@ -61,7 +79,8 @@ var tests = []test{
 			Template: "hello $(msg)",
 		},
 		Output: &Test{
-			Template: "hello world",
+			Template:   "hello world",
+			Properties: json.RawMessage{},
 		},
 	},
 	{
@@ -96,7 +115,8 @@ var tests = []test{
 			},
 		},
 		Output: &Test{
-			Template: "Special Agent - James Bond!",
+			Template:   "Special Agent - James Bond!",
+			Properties: json.RawMessage{},
 			Labels: map[string]string{
 				"address":   "London, UK",
 				"eye color": "light blue",
@@ -135,7 +155,8 @@ var tests = []test{
 			},
 		},
 		Output: &Test{
-			Template: "world",
+			Template:   "world",
+			Properties: json.RawMessage{},
 			JSONMap: map[string]any{
 				"a": map[string]any{
 					"b": map[string]any{
@@ -187,6 +208,7 @@ var tests = []test{
 			},
 		},
 		Output: &Test{
+			Properties: json.RawMessage{},
 			JSONMap: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",


### PR DESCRIPTION
We need this to template playbook parameter.properties.