### PR TITLE
fix(conv): correct bounds check in ToInt to resolve CodeQL integer-conversion alert

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -222,7 +222,7 @@ func ToInt(in interface{}) int {
 	// Protect against CWE-190 and CWE-681
 	// https://cwe.mitre.org/data/definitions/190.html
 	// https://cwe.mitre.org/data/definitions/681.html
-	if i := ToInt64(in); i <= math.MaxInt || i >= math.MinInt {
+	if i := ToInt64(in); i >= math.MinInt && i <= math.MaxInt {
 		return int(i)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the single open CodeQL code-scanning alert on `main`:

- **`go/incorrect-integer-conversion`** (CWE-681) — `conv/conv.go:225` (`ToInt`)

## The problem

`ToInt` guarded its `int64 → int` conversion with a tautology:

```go
if i := ToInt64(in); i <= math.MaxInt || i >= math.MinInt {
    return int(i)
}
```

Every `int64` value satisfies *at least one* side of that `||`, so the condition is **always true** and `int(i)` was executed with no effective range check. The tainted value flows from `strconv.ParseInt` (`strToInt64`) → `ToInt64` → `ToInt`, which is exactly the path CodeQL flags. On a 32-bit platform an out-of-range value would be silently truncated instead of returning the intended `-1` sentinel described by the comment just below.

## The fix

```go
if i := ToInt64(in); i >= math.MinInt && i <= math.MaxInt {
    return int(i)
}
```

Using `&&` verifies the value lies within `[math.MinInt, math.MaxInt]` before converting.

- On 64-bit platforms (`MinInt == MinInt64`, `MaxInt == MaxInt64`) behaviour is unchanged.
- On 32-bit platforms out-of-range values now correctly fall through to `return -1`.

## Verification

Because GitHub scans this repo with the **default** CodeQL query suite (the workflow specifies no custom queries), I reproduced the alert locally with the matching CodeQL bundle (`v2.26.1`) and the `go-code-scanning.qls` suite:

- **Before:** 1 alert — `go/incorrect-integer-conversion` at `conv/conv.go:226`.
- **After:** 0 alerts (full default suite re-run against a freshly rebuilt database).
- `go test ./conv/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRikukPomDzH3VYribFNPU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRikukPomDzH3VYribFNPU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected integer conversion boundary validation.
  * Values outside the supported integer range are now rejected consistently instead of being converted incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->