### PR TITLE
fix: resolve remaining CodeQL code-scanning alerts

### DIFF
--- a/docs/layouts/partials/footer_js.html
+++ b/docs/layouts/partials/footer_js.html
@@ -85,7 +85,7 @@
       </script>
     {{ end }}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
-    <script>hljs.initHighlightingOnLoad();</script>
+    <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.11.1/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
+    <script>hljs.highlightAll();</script>
   </body>
 </html>

--- a/js/shared.js
+++ b/js/shared.js
@@ -37,5 +37,5 @@ function endsWith(s, search) {
   if (s == null) {
     return false;
   }
-  return s.substring(s.length - search.length) === search;
+  return search.length <= s.length && s.substring(s.length - search.length) === search;
 }


### PR DESCRIPTION
## Summary

Resolves the open [CodeQL code-scanning alerts](https://github.com/flanksource/gomplate/security/code-scanning):

| Alert | Location | Severity | Fix |
|-------|----------|----------|-----|
| Inclusion of functionality from an untrusted source | `docs/layouts/partials/footer_js.html:88` | Medium | Add SRI + `crossorigin` to the highlight.js script |
| Incorrect suffix check | `js/shared.js:40` | High | Guard `endsWith` against an over-long suffix |
| Client-side XSS (×2) | `docs/static/js/search.js:25,35` | High | Already fixed on `main` (see below) |

## Details

### Inclusion of functionality from an untrusted source — `footer_js.html`
The highlight.js bundle was loaded from a hardcoded CDN URL with no integrity check, so a compromised/hijacked CDN response would execute arbitrary script on the docs site. Added a **Subresource Integrity** hash and `crossorigin="anonymous"`, and moved to the maintained **highlight.js v11.11.1** build.

- The SRI hash is derived from the official `@highlightjs/cdn-assets@11.11.1` npm artifact, which jsdelivr serves byte-for-byte — so the `integrity` value is guaranteed to match what browsers fetch.
- v11 removed `initHighlightingOnLoad()`; replaced with `hljs.highlightAll()`.

```html
<script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.11.1/highlight.min.js"
        integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU"
        crossorigin="anonymous"></script>
<script>hljs.highlightAll();</script>
```

### Incorrect suffix check — `js/shared.js`
`endsWith()` computed `s.substring(s.length - search.length)` without checking that `search` isn't longer than `s`. When it is, the start index is negative, `substring` clamps it to `0`, and the check reduces to `s === search` — the error-prone pattern CodeQL flags. Added an explicit `search.length <= s.length` guard.

The manual implementation is kept intentionally: `shared.js` is embedded and evaluated in the **ES5 [otto](https://github.com/robertkrimen/otto) runtime**, which has no native `String.prototype.endsWith`. Behavior is unchanged for all valid inputs (verified against a set of cases).

### Client-side cross-site scripting — `search.js`
These two alerts were already resolved on `main` in #165, which switched the reflected search query from `$(...).replaceWith(searchQuery)` (an HTML sink) to `$(...).text(searchQuery)` (text, not HTML). No further change is needed; they will auto-close on the next scan.

## Verification
- `go build ./...` and `go vet ./js/...` pass (the embedded `shared.js` is valid ES5).
- `endsWith` behavior validated against edge cases (suffix longer than string, empty strings, exact match).

## Note (not in scope of these alerts)
`docs/config.toml` also loads `fuse.js` and `mark.js` from cdnjs without SRI. CodeQL does not flag those because they reach the template through a variable (`{{ . | absURL }}`) rather than a literal URL, but they're the same class of issue and could be given SRI in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAXAPgXCc5TpEeZiFbwkhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAXAPgXCc5TpEeZiFbwkhf)_