### PR TITLE
fix: bump actions/upload-artifact to v4 in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -55,7 +55,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
## Summary

The `Scorecard supply-chain security` workflow was failing because it pinned `actions/upload-artifact@v3.1.0`. GitHub has [deprecated the v3 artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and now auto-fails any run that uses them.

## Changes

- Bump the `Upload artifact` step to `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2), keeping the existing SHA-pinning convention. The SHA was verified against the upstream v4.6.2 release tag.

The other actions in the workflow (checkout, scorecard-action, codeql upload-sarif) aren't affected by this deprecation and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTdFyubvvxGwAdkGvnZuUA)_