### PR TITLE
fix: upgrade Scorecard action for Sigstore compatibility

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The Scorecard workflow fails while signing results because v2.1.2 uses an outdated Sigstore/Cosign client that cannot process current TUF root keys.

Upgrade `ossf/scorecard-action` to v2.4.3 so Scorecard results can be signed and published successfully.